### PR TITLE
add namespace impl for obabeliface

### DIFF
--- a/obabeliface/obabeliface.cpp
+++ b/obabeliface/obabeliface.cpp
@@ -155,7 +155,7 @@ namespace Molsketch
   }
 
   Molecule fromOBMolecule(OpenBabel::OBMol& obmol) {
-    using namespace OpenBabel;
+    using namespace OpenBabel::impl;
 
     std::vector<Atom> atoms;
     std::map<OBAtom*, unsigned> atomNumbers;
@@ -205,7 +205,7 @@ namespace Molsketch
   }
 
   void setWedgeAndHash(OpenBabel::OBMol& mol) {
-      using namespace OpenBabel;
+      using namespace OpenBabel::impl;
     // Remove any existing wedge and hash bonds
     FOR_BONDS_OF_MOL(b, &mol)  {
 #if (OB_VERSION >= OB_VERSION_CHECK(3, 0, 0))


### PR DESCRIPTION
openbabel has added namespace impl :
https://github.com/openbabel/openbabel/commit/a0ec8c96554d4ee4f9bf80b00165b1ce554c8621

And then clang get errors :
> Molsketch-0.8.1/obabeliface/obabeliface.cpp:199:5: error: use of undeclared identifier 'impl'; did you mean 'OpenBabel::impl'?
>  199 |     FOR_ATOMS_OF_MOL(obatom, molecule) {
>      |     ^
> /usr/include/openbabel3/openbabel/obiter.h:417:49: note: expanded from macro 'FOR_ATOMS_OF_MOL'
>  417 | #define FOR_ATOMS_OF_MOL(a,m)     for (auto a : impl::MolGetAtoms(m))
>      |                                                 ^
> /usr/include/openbabel3/openbabel/obiter.h:401:13: note: 'OpenBabel::impl' declared here
>  401 |   namespace impl {
>      |             ^

This is only an immediate fix