### PR TITLE
fix namespace for obabeliface

### DIFF
--- a/obabeliface/obabeliface.cpp
+++ b/obabeliface/obabeliface.cpp
@@ -190,6 +190,9 @@ namespace Molsketch
 
   // TODO should be const, but OpenBabel iterator methods do not support const
   bool hasCoordinates(OpenBabel::OBMol &molecule) {
+#if (OB_VERSION >= OB_VERSION_CHECK(3, 0, 0))
+    using namespace OpenBabel;
+#endif
     FOR_ATOMS_OF_MOL(obatom, molecule) {
       if (obatom->GetVector() != OpenBabel::VZero)
         return true;


### PR DESCRIPTION
openbabel has changed namespaces :
https://github.com/openbabel/openbabel/commit/a0ec8c96554d4ee4f9bf80b00165b1ce554c8621

> Molsketch-0.8.1/obabeliface/obabeliface.cpp:199:5: error: use of undeclared identifier 'impl'; did you mean 'OpenBabel::impl'?
>  199 |     FOR_ATOMS_OF_MOL(obatom, molecule) {
>      |     ^
> /usr/include/openbabel3/openbabel/obiter.h:417:49: note: expanded from macro 'FOR_ATOMS_OF_MOL'
>  417 | #define FOR_ATOMS_OF_MOL(a,m)     for (auto a : impl::MolGetAtoms(m))
>      |                                                 ^
> /usr/include/openbabel3/openbabel/obiter.h:401:13: note: 'OpenBabel::impl' declared here
>  401 |   namespace impl {
>      |             ^